### PR TITLE
Minor fixes: zsh autostart, wrong path for fonts, vim plugins not installed

### DIFF
--- a/files/vimrc
+++ b/files/vimrc
@@ -23,7 +23,16 @@ if &term =~ '256color'
 endif
 
 set background=dark
-colorscheme vim-material
+
+try
+    colorscheme vim-material
+catch /^Vim\%((\a\+)\)\=:E185/
+    " Catches E185 exception (colorscheme not found)
+    " Used `:help catch` as inspiration
+
+    " Defining a fallback when `vim-material` does not exist.
+    colorscheme default
+endtry
 
 let g:airline_theme='material'
 let g:airline_powerline_fonts = 1

--- a/files/zshrc
+++ b/files/zshrc
@@ -23,4 +23,4 @@ export DOCKER_MYSQL_ROOT_PASSWORD=""
 export UID=$(id -u)
 export GID=$(id -g)
 export PATH=$HOME/.config/composer/vendor/bin:$PATH
-export PATH=$PATH:/home/rob/.local/bin
+export PATH=$PATH:$HOME/.local/bin

--- a/main.sh
+++ b/main.sh
@@ -60,7 +60,8 @@ if [ "$INSTALL_PROGRAMS" ]; then
         neofetch htop
 
     say "installing oh-my-zsh"
-    sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+    # Preventing ZSH from autostarting and hijacking current terminal session after install
+    RUNZSH="no" sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 
     say "installing vim-plug"
     curl -sfLo ~/.vim/autoload/plug.vim --create-dirs \

--- a/main.sh
+++ b/main.sh
@@ -95,9 +95,11 @@ if [ "$INSTALL" ]; then
     done
 fi
 
-if [ "$INSTALL_PROGRAMS" ] && [ "$INSTALL" ]; then                                 
-    say "installing vim plugins"                                                   
-    vim -u ~/.vimrc +PlugInstall +qall
+if [ "$INSTALL_PROGRAMS" ] && [ "$INSTALL" ]; then
+    say "installing vim plugins"
+    # `vimrc`` has to be specified as it is run from shell
+    # -e -s allow to start vim fully silently
+    vim -u ~/.vimrc -e -s +PlugInstall +qall
 
     say "restart terminal for changes to take effect"
 fi     

--- a/main.sh
+++ b/main.sh
@@ -95,6 +95,13 @@ if [ "$INSTALL" ]; then
     done
 fi
 
+if [ "$INSTALL_PROGRAMS" ] && [ "$INSTALL" ]; then                                 
+    say "installing vim plugins"                                                   
+    vim -u ~/.vimrc +PlugInstall +qall
+
+    say "restart terminal for changes to take effect"
+fi     
+
 if [ "$INSTALL_THEME" ]; then
     git clone https://github.com/robertalexa/gtk-theme-framework.git ~/.misc/gtk-theme-framework
     ~/.misc/gtk-theme-framework/main.sh -t oceanic -iosvc

--- a/main.sh
+++ b/main.sh
@@ -97,7 +97,7 @@ fi
 
 if [ "$INSTALL_PROGRAMS" ] && [ "$INSTALL" ]; then
     say "installing vim plugins"
-    # `vimrc`` has to be specified as it is run from shell
+    # `vimrc` has to be specified as it is run from shell
     # -e -s allow to start vim fully silently
     vim -u ~/.vimrc -e -s +PlugInstall +qall
 

--- a/main.sh
+++ b/main.sh
@@ -75,7 +75,9 @@ if [ "$INSTALL_PROGRAMS" ]; then
 
     say "installing meslo font"
     mkdir -p ~/.local/share/fonts/
-    cp ./fonts/*.ttf ~/.local/share/fonts/
+    # This ensures path is read and known regardless of the way of invoking script - directly or via `install.sh`
+    CURRENT_DIR=$(dirname -- "$( readlink -f -- "$0" )")
+    cp $CURRENT_DIR/fonts/*.ttf ~/.local/share/fonts/
 
     say "clearing font cache"
     fc-cache -f -v > /dev/null 2>&1


### PR DESCRIPTION
Hey,

I have recently been using your `.dotfiles` as they are handy.

However, there were couple of bugs:

- `zsh` autostarts resulting is terminal session hijack. Basically, user has to type `exit` to exit `zsh` session and come back to previous shell (i.e. `bash`). Luckily, `zsh` install supports various install flags. One of them - `RUNZSH="no"`, [source](https://github.com/ohmyzsh/ohmyzsh/blob/8a6fc5c16d49368dc8f9ddd965a9e25ef652e129/tools/install.sh#L29C5-L29C11). This still prompts to whether or not set `zsh` as default shell, but does not kickstart `zsh` session afterwards.
- Most likely script is going to be run via `wget ... install.sh` while within `home` directory. Font install rely on relative path within `main.sh`. But since repo going to be cloned to `/.misc/dotfiles`, using `cp ./fonts/*.ttf` will fail, as `.` is currently pointing at `home`. Hence, added extra lines to ensure script "knows" which directory it is in and where to look for fonts
- initially, `vim-material` does not exist because vim plugins are not installed. This requires manual user input to install the plugins and download `vim-material` colorscheme. Hence, `vimrc` is modified to handle absence of `vim-material` colorscheme, allowing to start vim with default colorscheme without throwing any errors. Then, `vim` plugins can be safely installed as a last step before terminating install script. `vim` runs without any GUI when installing plugins.
- Changed `/home/rob` to `$HOME` for flexibility

I have tested that on my Ubuntu 23.04 as a VM